### PR TITLE
GET /api

### DIFF
--- a/__tests__/app.test.js
+++ b/__tests__/app.test.js
@@ -18,6 +18,18 @@ describe ('/api/does-not-exist', () => {
     })
 })
 
+describe('/api', () => {
+    test('GET 200: responds with an object describing all the available endpoints on the API', () => {
+        const endpoints = require('../endpoints.json')
+        return request(app)
+        .get('/api')
+        .expect(200)
+        .then(({ body }) => {
+            expect(body).toEqual(endpoints)
+        })
+    })
+})
+
 describe ('/api/topics', () => {
     test('GET 200: responds with an array of topic objects, each with slug and description properties', () => {
         return request(app)

--- a/app.js
+++ b/app.js
@@ -1,9 +1,15 @@
 const express = require('express')
 const { getTopics } = require('./controllers/topics.controllers')
+const endpoints = require('./endpoints.json')
 
 const app = express()
 
+app.use(express.json())
 // endpoints:
+
+app.get('/api', (req, res, next) => {
+    res.status(200).send(endpoints)
+})
 
 app.get('/api/topics', getTopics)
 


### PR DESCRIPTION
Implements the /api endpoint as described in task 3

## Tests

* Tests that a GET request to /api will respond with an object that matches the data in the endpoints.json file
* Requires that endpoints file into the test for comparison and into the app.js for use
* Simply sends the file with a 200 status to a GET on the /api endpoint

## Notes
* I implemented this directly in  the app.js file, as we know it won't be talking to the db, I thought it might be simpler to deal with it there rather than make a controller file just for this one request. Happy to change this if that's not the right approach though. 