### PR TITLE
GET /api/articles

### DIFF
--- a/__tests__/app.test.js
+++ b/__tests__/app.test.js
@@ -46,6 +46,49 @@ describe ('/api/topics', () => {
     })
 })
 
+describe('/api/articles', () => {
+    test('GET 200: responds with an articles array of article objects with all article properties but no body', () => {
+        return request(app)
+        .get('/api/articles')
+        .expect(200)
+        .then(({ body }) => {
+            console.log(body, '<<< body in test')
+            const { articles } = body
+            expect(articles.length).toBe(13)
+            articles.forEach((article) => {
+                const { author, title, article_id, topic, created_at, votes, article_img_url } = article
+                expect(typeof author).toBe('string')
+                expect(typeof title).toBe('string')
+                expect(typeof article_id).toBe('number')
+                expect(typeof created_at).toBe('string')
+                expect(typeof votes).toBe('number')
+                expect(typeof article_img_url).toBe('string')
+                expect(typeof topic).toBe('string')
+                expect(article).not.toHaveProperty('body')
+            })
+        })
+    })
+    test('GET 200: responds with correct comment_count from comments table via JOIN on article_id, parsed into a number', () => {
+        return request(app)
+        .get('/api/articles')
+        .expect(200)
+        .then(({ body }) => {
+            const { articles } = body
+            const test_article = articles[0]
+            expect(test_article.comment_count).toBe(2)
+        })
+    })
+    test('GET 200: responds with articles sorted in descending date order by default', () => {
+        return request(app)
+        .get('/api/articles')
+        .expect(200)
+        .then(({ body }) => {
+            const { articles } = body
+            expect(articles).toBeSortedBy('created_at', {descending: true})
+        })
+    })
+})
+
 describe('/api/articles/:article_id', () => {
     test('GET 200: responds with article object with the requested id with all required properties', () => {
         return request(app)

--- a/app.js
+++ b/app.js
@@ -1,17 +1,17 @@
 const express = require('express')
 const endpoints = require('./endpoints.json')
 const { getTopics } = require('./controllers/topics.controllers')
-const { getArticleById } = require('./controllers/articles.controllers')
+const { getArticleById, getArticles } = require('./controllers/articles.controllers')
 
 const app = express()
 
 // endpoints:
 
-app.get('/api', (req, res, next) => {
-    res.status(200).send(endpoints)
-})
+app.get('/api', (req, res, next) => res.status(200).send(endpoints))
 
 app.get('/api/topics', getTopics)
+
+app.get('/api/articles', getArticles)
 
 app.get('/api/articles/:article_id', getArticleById)
 
@@ -40,7 +40,7 @@ app.use((err, req, res, next) => {
   })
 // default to 500 error for any uncaught errors:
 app.use((err, req, res, next) => {
-    console.log(err, '<-- err at end')
+    //console.log(err, '<-- err at end')
     res.status(500).send({ msg: 'Internal server error'})
 })
 

--- a/controllers/articles.controllers.js
+++ b/controllers/articles.controllers.js
@@ -1,4 +1,11 @@
-const { selectArticleById } = require("../models/articles.models")
+const { selectArticleById, selectArticles } = require("../models/articles.models")
+
+exports.getArticles = (req, res, next) => {
+    return selectArticles().then((articles) => {
+        res.status(200).send({ articles })
+    })
+    .catch(next)
+}
 
 exports.getArticleById = (req, res, next) => {
     const { article_id } = req.params

--- a/endpoints.json
+++ b/endpoints.json
@@ -11,7 +11,7 @@
   },
   "GET /api/articles": {
     "description": "serves an array of all articles",
-    "queries": ["author", "topic", "sort_by", "order"],
+    "queries": [],
     "exampleResponse": {
       "articles": [
         {
@@ -27,8 +27,7 @@
     }
   },
   "GET /api/articles/:article_id": {
-    "description": "serves one article with article_id specified in endpoint",
-    "params": ["article_id"],
+    "description": "serves the article with the article_id specified in endpoint",
     "queries": [],
     "exampleResponse": {
       "article": [

--- a/models/articles.models.js
+++ b/models/articles.models.js
@@ -1,10 +1,38 @@
 const db = require('../db/connection')
 
+exports.selectArticles = () => {
+    return db.query(`
+    SELECT  a.author,
+            a.title,
+            a.article_id,
+            a.created_at,
+            a.votes,
+            a.article_img_url,
+            a.topic,
+            COUNT(c.comment_id) AS comment_count
+    FROM articles a 
+    LEFT JOIN comments c
+    ON a.article_id = c.article_id
+    GROUP BY a.author,
+            a.title,
+            a.article_id,
+            a.created_at,
+            a.votes,
+            a.article_img_url,
+            a.topic
+    ORDER BY a.created_at DESC
+    ;`)
+    .then(({ rows }) => {
+        rows.forEach((article) => article.comment_count = parseInt(article.comment_count))
+        return rows
+    })
+}
+
 exports.selectArticleById = (article_id) => {
     return db.query(`
         SELECT * FROM articles
-        WHERE article_id = $1;
-    `, [article_id])
+        WHERE article_id = $1
+    ;`, [article_id])
     .then(({ rows }) => {
         if (rows.length === 0){
             return Promise.reject({ status: 404, msg: "Article not found" })

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
       "dependencies": {
         "dotenv": "^16.0.0",
         "express": "^4.19.2",
+        "jest-sorted": "^1.0.15",
         "pg": "^8.7.3",
         "supertest": "^6.3.4"
       },
@@ -3244,6 +3245,11 @@
       "engines": {
         "node": ">=10"
       }
+    },
+    "node_modules/jest-sorted": {
+      "version": "1.0.15",
+      "resolved": "https://registry.npmjs.org/jest-sorted/-/jest-sorted-1.0.15.tgz",
+      "integrity": "sha512-bb5HzfyUqv22ToD63KRACZiwHVRVVj6/bl53VOODNQSzmTwKuTM0zYI73aByYulYVkugPmgGBXUTY8YLJYotKw=="
     },
     "node_modules/jest-util": {
       "version": "27.5.1",
@@ -7540,6 +7546,11 @@
           }
         }
       }
+    },
+    "jest-sorted": {
+      "version": "1.0.15",
+      "resolved": "https://registry.npmjs.org/jest-sorted/-/jest-sorted-1.0.15.tgz",
+      "integrity": "sha512-bb5HzfyUqv22ToD63KRACZiwHVRVVj6/bl53VOODNQSzmTwKuTM0zYI73aByYulYVkugPmgGBXUTY8YLJYotKw=="
     },
     "jest-util": {
       "version": "27.5.1",

--- a/package.json
+++ b/package.json
@@ -24,17 +24,19 @@
     "husky": "^8.0.2",
     "jest": "^27.5.1",
     "jest-extended": "^2.0.0",
+    "jest-sorted": "^1.0.15",
+    "supertest": "^6.3.4",
     "pg-format": "^1.0.4"
   },
   "dependencies": {
     "dotenv": "^16.0.0",
     "express": "^4.19.2",
-    "pg": "^8.7.3",
-    "supertest": "^6.3.4"
+    "pg": "^8.7.3"
   },
   "jest": {
     "setupFilesAfterEnv": [
-      "jest-extended/all"
+      "jest-extended/all",
+      "jest-sorted"
     ]
   }
 }


### PR DESCRIPTION
## Setup / config
* Installs jest-sorted for sort order testing
* Moves some dependencies to dev-dependencies in package.json (hoping this is the right way to correct installing them as normal dependencies by mistake)

## Endpoint implementation
* Adds tests for a successful GET on /api/articles
* 1st test deals with the simple properties that don't require a JOIN, and checks that 'body' property is not present
* 2nd test is for the comment_count that requires a JOIN and a COUNT aggregate function
* The result of the COUNT comes back from db  as a string so I have parsed it to a number in the model
* Final happy path test is for implementing the default date descending ordering

## Notes
* Deleted the queries that had been put in for /api/articles from the endpoints.json for now, as they have not yet been implemented
* With a generic 404 already implemented for any mistyped endpoints, and the catch-all 500, I struggled to think of any specific errors for this endpoint - but please let me know if I am missing something here