### PR TITLE
Ticket 6: GET /api/articles/:article_id/comments

### DIFF
--- a/__tests__/app.test.js
+++ b/__tests__/app.test.js
@@ -129,8 +129,7 @@ describe('/api/articles/:article_id/comments', () => {
         return request(app)
         .get('/api/articles/1/comments')
         .expect(200)
-        .then(({ body }) => {
-            const { comments } = body
+        .then(({ body: { comments } }) => {
             expect(comments.length).toBe(11)
             comments.forEach((comment => {
                 const {comment_id, votes, created_at, author, body, article_id} = comment
@@ -147,8 +146,7 @@ describe('/api/articles/:article_id/comments', () => {
         return request(app)
         .get('/api/articles/1/comments')
         .expect(200)
-        .then(({ body }) => {
-            const { comments } = body
+        .then(({ body: { comments } }) => {
             expect(comments).toBeSortedBy('created_at', { descending: true })
         })
     })

--- a/__tests__/app.test.js
+++ b/__tests__/app.test.js
@@ -111,17 +111,17 @@ describe('/api/articles/:article_id', () => {
         .get('/api/articles/9999')
         .expect(404)
         .then(({ body }) => {
-            expect(body.msg).toBe('Article not found');
-        });
+            expect(body.msg).toBe('Article not found')
+        })
     })
     test('GET 400: responds with a bad request error if article_id is not valid', () => {
         return request(app)
-          .get('/api/articles/not-a-number')
-          .expect(400)
-          .then(({ body }) => {
-            expect(body.msg).toBe('Bad request');
-          });
-      });
+            .get('/api/articles/not-a-number')
+            .expect(400)
+            .then(({ body }) => {
+            expect(body.msg).toBe('Bad request')
+        })
+    })
 })
 
 describe('/api/articles/:article_id/comments', () => {
@@ -157,7 +157,15 @@ describe('/api/articles/:article_id/comments', () => {
         .get('/api/articles/9999/comments')
         .expect(404)
         .then(({ body: { msg } }) => {
-            expect(msg).toBe('Article not found');
+            expect(msg).toBe('Article not found')
         });
     })
+    test('GET 400: responds with a bad request error if article_id is not valid', () => {
+        return request(app)
+            .get('/api/articles/not-a-number/comments')
+            .expect(400)
+            .then(({ body: { msg } }) => {
+            expect(msg).toBe('Bad request')
+        })
+    })  
 })

--- a/__tests__/app.test.js
+++ b/__tests__/app.test.js
@@ -52,7 +52,6 @@ describe('/api/articles', () => {
         .get('/api/articles')
         .expect(200)
         .then(({ body }) => {
-            console.log(body, '<<< body in test')
             const { articles } = body
             expect(articles.length).toBe(13)
             articles.forEach((article) => {
@@ -150,8 +149,15 @@ describe('/api/articles/:article_id/comments', () => {
         .expect(200)
         .then(({ body }) => {
             const { comments } = body
-            console.log(comments)
             expect(comments).toBeSortedBy('created_at', { descending: true })
         })
+    })
+    test('GET 404: responds with a not found error if article_id is valid but does not exist in db', () => {
+        return request(app)
+        .get('/api/articles/9999/comments')
+        .expect(404)
+        .then(({ body: { msg } }) => {
+            expect(msg).toBe('Article not found');
+        });
     })
 })

--- a/__tests__/app.test.js
+++ b/__tests__/app.test.js
@@ -167,5 +167,13 @@ describe('/api/articles/:article_id/comments', () => {
             .then(({ body: { msg } }) => {
             expect(msg).toBe('Bad request')
         })
-    })  
+    })
+    test('GET 200: responds with an empty array if the article_id exists but has no comments', () => {
+        return request(app)
+        .get('/api/articles/2/comments')
+        .expect(200)
+        .then(({ body: { comments } }) => {
+            expect(comments).toHaveLength(0)
+        })
+    })
 })

--- a/__tests__/app.test.js
+++ b/__tests__/app.test.js
@@ -124,3 +124,34 @@ describe('/api/articles/:article_id', () => {
           });
       });
 })
+
+describe('/api/articles/:article_id/comments', () => {
+    test('GET 200: responds with array of comments for the given article_id with all correct properties', () => {
+        return request(app)
+        .get('/api/articles/1/comments')
+        .expect(200)
+        .then(({ body }) => {
+            const { comments } = body
+            expect(comments.length).toBe(11)
+            comments.forEach((comment => {
+                const {comment_id, votes, created_at, author, body, article_id} = comment
+                expect(typeof comment_id).toBe('number')
+                expect(typeof votes).toBe('number')
+                expect(typeof created_at).toBe('string')
+                expect(typeof author).toBe('string')
+                expect(typeof body).toBe('string')
+                expect(typeof article_id).toBe('number')
+            }))
+        })
+    })
+    test('Get 200: responds with comments array ordered in date descending by default', () => {
+        return request(app)
+        .get('/api/articles/1/comments')
+        .expect(200)
+        .then(({ body }) => {
+            const { comments } = body
+            console.log(comments)
+            expect(comments).toBeSortedBy('created_at', { descending: true })
+        })
+    })
+})

--- a/app.js
+++ b/app.js
@@ -2,6 +2,7 @@ const express = require('express')
 const endpoints = require('./endpoints.json')
 const { getTopics } = require('./controllers/topics.controllers')
 const { getArticleById, getArticles } = require('./controllers/articles.controllers')
+const { getCommentsByArticleId } = require('./controllers/comments.controllers')
 
 const app = express()
 
@@ -14,6 +15,8 @@ app.get('/api/topics', getTopics)
 app.get('/api/articles', getArticles)
 
 app.get('/api/articles/:article_id', getArticleById)
+
+app.get('/api/articles/:article_id/comments', getCommentsByArticleId)
 
 
 // respond with 404 for any undefined endpoints:

--- a/app.js
+++ b/app.js
@@ -43,7 +43,6 @@ app.use((err, req, res, next) => {
   })
 // default to 500 error for any uncaught errors:
 app.use((err, req, res, next) => {
-    //console.log(err, '<-- err at end')
     res.status(500).send({ msg: 'Internal server error'})
 })
 

--- a/controllers/comments.controllers.js
+++ b/controllers/comments.controllers.js
@@ -5,4 +5,5 @@ exports.getCommentsByArticleId = (req, res, next) => {
     return selectCommentsByArticleId(article_id).then((comments) => {
         res.status(200).send({ comments })
     })
+    .catch(next)
 }

--- a/controllers/comments.controllers.js
+++ b/controllers/comments.controllers.js
@@ -1,0 +1,8 @@
+const { selectCommentsByArticleId } = require("../models/comments.models")
+
+exports.getCommentsByArticleId = (req, res, next) => {
+    const { article_id } = req.params
+    return selectCommentsByArticleId(article_id).then((comments) => {
+        res.status(200).send({ comments })
+    })
+}

--- a/controllers/comments.controllers.js
+++ b/controllers/comments.controllers.js
@@ -1,8 +1,11 @@
+const { checkArticleExists } = require("../models/articles.models")
 const { selectCommentsByArticleId } = require("../models/comments.models")
 
 exports.getCommentsByArticleId = (req, res, next) => {
     const { article_id } = req.params
-    return selectCommentsByArticleId(article_id).then((comments) => {
+
+    return Promise.all([selectCommentsByArticleId(article_id), checkArticleExists(article_id)])
+    .then(([ comments ]) => {
         res.status(200).send({ comments })
     })
     .catch(next)

--- a/endpoints.json
+++ b/endpoints.json
@@ -43,5 +43,21 @@
         }
       ]
     }
+  },
+  "GET /api/articles/:article_id/comments": {
+    "description": "serves comments associated with article specified by article_id, serves empty array for an article with no comments",
+    "queries": [],
+    "exampleResponse": {
+      "comments": [
+        {
+          "comment_id": 5,
+          "body": "I hate streaming noses",
+          "article_id": 1,
+          "author": "icellusedkars",
+          "votes": 0,       
+          "created_at": "2020-11-03T21:00:00.000Z"
+        }
+      ]
+    }
   }
 }

--- a/models/articles.models.js
+++ b/models/articles.models.js
@@ -40,3 +40,16 @@ exports.selectArticleById = (article_id) => {
         return rows[0]
     })
 }
+
+exports.checkArticleExists = (article_id) => {
+    return db.query(`
+        SELECT * FROM articles
+        WHERE article_id = $1
+        ;`, [article_id])
+    .then(({ rows }) => {
+        if (rows.length === 0){
+            return Promise.reject({ status: 404, msg: "Article not found" })
+        }
+        return
+    })
+}

--- a/models/comments.models.js
+++ b/models/comments.models.js
@@ -7,6 +7,9 @@ exports.selectCommentsByArticleId = (article_id) => {
         ORDER BY created_at DESC
     ;`, [article_id])
     .then(({ rows }) => {
+        if (rows.length === 0){
+            return Promise.reject({ status: 404, msg: "Article not found" })
+          }
         return rows
     })
 }

--- a/models/comments.models.js
+++ b/models/comments.models.js
@@ -7,9 +7,6 @@ exports.selectCommentsByArticleId = (article_id) => {
         ORDER BY created_at DESC
     ;`, [article_id])
     .then(({ rows }) => {
-        if (rows.length === 0){
-            return Promise.reject({ status: 404, msg: "Article not found" })
-          }
         return rows
     })
 }

--- a/models/comments.models.js
+++ b/models/comments.models.js
@@ -1,0 +1,12 @@
+const db = require('../db/connection')
+
+exports.selectCommentsByArticleId = (article_id) => {
+    return db.query(`
+        SELECT * FROM comments
+        WHERE article_id = $1
+        ORDER BY created_at DESC
+    ;`, [article_id])
+    .then(({ rows }) => {
+        return rows
+    })
+}


### PR DESCRIPTION
## Setup / config
* Adds comments.controllers and comments.models files

## Endpoint implementation
* Adds happy path tests for a GET on /api/articles/:article_id/comments and implements functionality to pass
* Adds 404 and 400 sad path tests for non-existent and non-valid article_id and passes them
* Adds another GET 200 test for cases where an article_id exists but has no associated comments, to serve an empty array.
* This is dealt with by creating a function to check if article exists in the articles model which rejects if not, then implementing a Promise.all in the comments controller that calls that function as well as the one to select comments 

## Other
* Updates endpoints.json with details for this endpoint

## Notes
* I added a 400 test for invalid path here which was already passing due to having already dealt with a 22P02 db error from the previous endpoint. Would best practice be to keep this test in or delete it as it was already passing?
* Improved destructuring in the tests for this endpoint based on something I learned from this morning's lecture. Will refactor the previous ones for consistency later