### PR TITLE
Ticket 8b: PATCH /api/articles/:article_id updates

### DIFF
--- a/__tests__/app.test.js
+++ b/__tests__/app.test.js
@@ -145,13 +145,23 @@ describe('/api/articles/:article_id', () => {
                 expect(article_img_url).toBe('https://images.pexels.com/photos/158651/news-newsletter-newspaper-information-158651.jpeg?w=700&h=700')
             })
         })
-        test('PATCH 400: responds with a bad request error if sent a malformed votes object', () => {
+        test('PATCH 400: responds with a bad request error if sent a votes object without inc_votes property', () => {
             const testPatch = { not_valid : 1 } 
             return request(app)
             .patch('/api/articles/1')
             .send(testPatch)
             .expect(400)
             .then(({ body}) => {
+                expect(body.msg).toBe('Bad request')
+            })
+        })
+        test('PATCH 400: responds with a bad request if inc_votes value is not a number', () => {
+            const testPatch = { inc_votes : 'not a number' } 
+            return request(app)
+            .patch('/api/articles/1')
+            .send(testPatch)
+            .expect(400)
+            .then(({ body })  => {
                 expect(body.msg).toBe('Bad request')
             })
         })

--- a/controllers/articles.controllers.js
+++ b/controllers/articles.controllers.js
@@ -18,8 +18,8 @@ exports.getArticleById = (req, res, next) => {
 exports.patchVotesByArticleId = (req, res, next) => {
     const { article_id } = req.params
     const body = req.body
-    return Promise.all([updateVotesByArticleId(article_id, body), checkArticleExists(article_id)])
-    .then(([ article ]) => {
+    return updateVotesByArticleId(article_id, body)
+    .then((article) => {
         res.status(200).send({ article })
     })
     .catch(next)

--- a/models/articles.models.js
+++ b/models/articles.models.js
@@ -36,7 +36,7 @@ exports.selectArticleById = (article_id) => {
     .then(({ rows }) => {
         if (rows.length === 0){
             return Promise.reject({ status: 404, msg: "Article not found" })
-          }
+        }
         return rows[0]
     })
 }
@@ -49,6 +49,9 @@ exports.updateVotesByArticleId = (article_id, { inc_votes } ) => {
         RETURNING *
     ;`, [inc_votes, article_id])
     .then(({ rows }) => {
+        if (rows.length === 0){
+            return Promise.reject({ status: 404, msg: "Article not found" })
+        }
         return rows[0]
     })
 }


### PR DESCRIPTION
# Updates to PATCH /api/articles/:article_id
Just responding to some feedback on a previous pull request

## Testing Enhancements
* Adds a test for a patch object that has correct inc_votes property but invalid value type (__400__)
* 22P02 code error that comes back from the db already set up to be caught in middleware

## Refactoring
* Refactors functions to reduce number of db queries 
	* removes Promise.all including separate query to check if article exists from controller
	* adds a rows length check in the model to throw __404__ error if it comes back empty