### PR TITLE
Ticket 12: GET /api/articles/:article_id (comment_count)

### DIFF
--- a/__tests__/app.test.js
+++ b/__tests__/app.test.js
@@ -152,6 +152,14 @@ describe('/api/articles/:article_id', () => {
                 expect(body.msg).toBe('Bad request')
             })
         })
+        test('GET 200: responds with article including accurate comment_count from comments table via JOIN on article_id', () => {
+            return request(app)
+            .get('/api/articles/1')
+            .expect(200)
+            .then(({ body : { article: { comment_count } } })=> {
+                expect(comment_count).toBe(11)
+           }) 
+        })
     })
     describe('PATCH TESTS', () => {
         test('PATCH 200: responds with correctly updated votes in article object', () => {

--- a/endpoints.json
+++ b/endpoints.json
@@ -38,7 +38,8 @@
           "body": "I find this existence challenging",
           "created_at": "2020-07-09 21:11:00",
           "votes": 100,
-          "article_img_url": "https://images.pexels.com/photos/158651/news-newsletter-newspaper-information-158651.jpeg?w=700&h=700"
+          "article_img_url": "https://images.pexels.com/photos/158651/news-newsletter-newspaper-information-158651.jpeg?w=700&h=700",
+          "comment_count": 11 
       }
     }
   },

--- a/models/articles.models.js
+++ b/models/articles.models.js
@@ -41,9 +41,30 @@ exports.selectArticles = (topic) => {
 
 exports.selectArticleById = (article_id) => {
     return db.query(`
-        SELECT * FROM articles
-        WHERE article_id = $1
-    ;`, [article_id])
+        SELECT  
+            a.author,
+            a.title,
+            a.article_id,
+            a.created_at,
+            a.body,
+            a.votes,
+            a.article_img_url,
+            a.topic,
+            COUNT(c.comment_id) :: INT AS comment_count 
+        FROM articles a 
+        LEFT JOIN comments c
+        ON a.article_id = c.article_id
+        WHERE a.article_id = $1
+        GROUP BY
+            a.author,
+            a.title,
+            a.article_id,
+            a.created_at,
+            a.body,
+            a.votes,
+            a.article_img_url,
+            a.topic
+        ;`, [article_id])
     .then(({ rows }) => {
         if (rows.length === 0){
             return Promise.reject({ status: 404, msg: "Article not found" })


### PR DESCRIPTION
# GET /api/articles/:article_id (comment_count)

## Feature testing & implementation
* Adds happy path __200__ test for new feature: __comment_count__ being included in article served back from GET requests on /api/articles/:article_id 
* Implemented via a JOIN to the comments table in the db query with a COUNT aggregate function
* COUNT gets cast to INT in psql via use of  double colon (`:: INT`)

## Notes
* Having now worked out how to get aggregate functions coming back from the db as numbers, will refactor the comment_count  implementation on /api/get/articles to do likewise
* No sad path tests implemented as this feature simply extends the previous GET request behaviour, and does not introduce new ways in which it could go wrong