### PR TITLE
GET /api/articles comment_count refactor

### DIFF
--- a/__tests__/app.test.js
+++ b/__tests__/app.test.js
@@ -72,7 +72,7 @@ describe('/api/articles', () => {
                 })
             })
         })
-        test('GET 200: responds with correct comment_count from comments table via JOIN on article_id, parsed into a number', () => {
+        test('GET 200: responds with correct comment_count from comments table via JOIN on article_id, cast as INT in psql', () => {
             return request(app)
             .get('/api/articles')
             .expect(200)

--- a/models/articles.models.js
+++ b/models/articles.models.js
@@ -9,7 +9,7 @@ exports.selectArticles = (topic) => {
         a.votes,
         a.article_img_url,
         a.topic,
-        COUNT(c.comment_id) AS comment_count
+        COUNT(c.comment_id) :: INT AS comment_count
         FROM articles a 
         LEFT JOIN comments c
         ON a.article_id = c.article_id 
@@ -34,7 +34,6 @@ exports.selectArticles = (topic) => {
 
     return db.query(sqlQueryString, queryValues)
     .then(({ rows }) => {
-        rows.forEach((article) => article.comment_count = parseInt(article.comment_count))
         return rows
     })
 }


### PR DESCRIPTION
# comment_count now coming back as a number
Having worked out how to cast the results of aggregate functions to INT in psql, so that they come back into the model as numbers, I went back and implemented this method for the COUNT in the selectArticles function

## Refactoring
* Adds `:: INT` to the COUNT aggregate function in the db query
* `COUNT(c.comment_id) :: INT AS comment_count`
* Removes the forEach that was parsing to integers in the model