### PR TITLE
Ticket 15: Sorting queries (GET /api/articles)

### DIFF
--- a/__tests__/app.test.js
+++ b/__tests__/app.test.js
@@ -107,12 +107,20 @@ describe('/api/articles', () => {
                 expect(body.msg).toBe('Topic not found')
             })
         })
-        test('GET 200: respons with an empty array if topic exists but has no associated articles', () => {
+        test('GET 200: responds with an empty array if topic exists but has no associated articles', () => {
             return request(app)
             .get('/api/articles?topic=paper')
             .expect(200)
             .then(({ body: { articles } }) => {
                 expect(articles).toHaveLength(0)
+            })
+        })
+        test('GET 200: responds with articles sorted in ascending date order if specified in order query', () => {
+            return request(app)
+            .get('/api/articles?order=asc')
+            .expect(200)
+            .then(({ body: { articles } }) => {
+                expect(articles).toBeSortedBy('created_at', {ascending: true})
             })
         })
     })

--- a/__tests__/app.test.js
+++ b/__tests__/app.test.js
@@ -123,6 +123,14 @@ describe('/api/articles', () => {
                 expect(articles).toBeSortedBy('created_at', {ascending: true})
             })
         })
+        test('GET 200: responds with articles sorted by a column specified in sort_by query', () => {
+            return request(app)
+            .get('/api/articles?sort_by=author&order=asc')
+            .expect(200)
+            .then(({ body: { articles } }) => {
+                expect(articles).toBeSortedBy('author', {ascending: true})
+            })
+        })
     })
 })
 

--- a/__tests__/app.test.js
+++ b/__tests__/app.test.js
@@ -147,6 +147,14 @@ describe('/api/articles', () => {
                 expect(msg).toBe('Bad request')
             })
        })
+       test('GET 404: responds with a not found error if specified sort_by column is invalid', () => {
+            return request(app)
+            .get('/api/articles?sort_by=invalid_column')
+            .expect(404)
+            .then(({ body: { msg } }) => {
+                expect(msg).toBe('Column not found')
+            })
+        })
     })
 })
 

--- a/__tests__/app.test.js
+++ b/__tests__/app.test.js
@@ -123,7 +123,7 @@ describe('/api/articles', () => {
                 expect(articles).toBeSortedBy('created_at', {ascending: true})
             })
         })
-        test('GET 200: responds with articles sorted by a column specified in sort_by query', () => {
+        test('GET 200: responds with articles sorted by a column from articles table specified in sort_by query', () => {
             return request(app)
             .get('/api/articles?sort_by=author&order=asc')
             .expect(200)
@@ -131,6 +131,15 @@ describe('/api/articles', () => {
                 expect(articles).toBeSortedBy('author', {ascending: true})
             })
         })
+        test('GET 200: responds with articles sorted by comment_count column from the JOIN if specified', () => {
+            return request(app)
+            .get('/api/articles?sort_by=comment_count')
+            .expect(200)
+            .then(({ body: { articles } }) => {
+                expect(articles).toBeSortedBy('comment_count', {descending: true})
+            })
+        })
+       
     })
 })
 

--- a/__tests__/app.test.js
+++ b/__tests__/app.test.js
@@ -139,7 +139,14 @@ describe('/api/articles', () => {
                 expect(articles).toBeSortedBy('comment_count', {descending: true})
             })
         })
-       
+       test('GET 400: responds with a bad request error if sort query is neither asc nor desc', () => {
+            return request(app)
+            .get('/api/articles?order=invalid_order')
+            .expect(400)
+            .then(({ body: { msg } }) => {
+                expect(msg).toBe('Bad request')
+            })
+       })
     })
 })
 

--- a/controllers/articles.controllers.js
+++ b/controllers/articles.controllers.js
@@ -2,8 +2,8 @@ const { selectArticleById, selectArticles, updateVotesByArticleId, checkArticleE
 const { checkTopicExists } = require("../models/topics.models")
 
 exports.getArticles = (req, res, next) => {
-    const { topic, order } = req.query
-    return Promise.all([selectArticles(topic, order), checkTopicExists(topic)])
+    const { topic, sort_by, order } = req.query
+    return Promise.all([selectArticles(topic, sort_by, order), checkTopicExists(topic)])
     .then(([ articles ]) => res.status(200).send({ articles }))
     .catch(next)
 }

--- a/controllers/articles.controllers.js
+++ b/controllers/articles.controllers.js
@@ -2,8 +2,8 @@ const { selectArticleById, selectArticles, updateVotesByArticleId, checkArticleE
 const { checkTopicExists } = require("../models/topics.models")
 
 exports.getArticles = (req, res, next) => {
-    const { topic } = req.query
-    return Promise.all([selectArticles(topic), checkTopicExists(topic)])
+    const { topic, order } = req.query
+    return Promise.all([selectArticles(topic, order), checkTopicExists(topic)])
     .then(([ articles ]) => res.status(200).send({ articles }))
     .catch(next)
 }

--- a/models/articles.models.js
+++ b/models/articles.models.js
@@ -3,10 +3,13 @@ const { commentData } = require('../db/data/test-data')
 
 exports.selectArticles = (topic, sort_by = 'created_at', order = 'desc') => {
     const validOrders = ['asc', 'desc']
+    const validSortBys = ['author', 'title', 'article_id', 'created_at', 'article_img_url', 'topic', 'comment_count']
     if(!validOrders.includes(order)){
         return Promise.reject({ status: 400, msg: 'Bad request'})
     }
-    
+    if(!validSortBys.includes(sort_by)){
+        return Promise.reject({ status: 404, msg: 'Column not found'})
+    }
     if(sort_by !== 'comment_count'){
         sort_by = `a.${sort_by}`
     }

--- a/models/articles.models.js
+++ b/models/articles.models.js
@@ -1,6 +1,11 @@
 const db = require('../db/connection')
+const { commentData } = require('../db/data/test-data')
 
 exports.selectArticles = (topic, sort_by = 'created_at', order = 'desc') => {
+    if(sort_by !== 'comment_count'){
+        sort_by = `a.${sort_by}`
+    }
+        
     let sqlQueryString = `
         SELECT  a.author,
         a.title,
@@ -29,7 +34,7 @@ exports.selectArticles = (topic, sort_by = 'created_at', order = 'desc') => {
         a.votes,
         a.article_img_url,
         a.topic
-        ORDER BY a.${sort_by} ${order}
+        ORDER BY ${sort_by} ${order}
     ;`
 
     return db.query(sqlQueryString, queryValues)

--- a/models/articles.models.js
+++ b/models/articles.models.js
@@ -2,10 +2,15 @@ const db = require('../db/connection')
 const { commentData } = require('../db/data/test-data')
 
 exports.selectArticles = (topic, sort_by = 'created_at', order = 'desc') => {
+    const validOrders = ['asc', 'desc']
+    if(!validOrders.includes(order)){
+        return Promise.reject({ status: 400, msg: 'Bad request'})
+    }
+    
     if(sort_by !== 'comment_count'){
         sort_by = `a.${sort_by}`
     }
-        
+
     let sqlQueryString = `
         SELECT  a.author,
         a.title,

--- a/models/articles.models.js
+++ b/models/articles.models.js
@@ -1,6 +1,6 @@
 const db = require('../db/connection')
 
-exports.selectArticles = (topic) => {
+exports.selectArticles = (topic, order = 'desc') => {
     let sqlQueryString = `
         SELECT  a.author,
         a.title,
@@ -29,7 +29,7 @@ exports.selectArticles = (topic) => {
         a.votes,
         a.article_img_url,
         a.topic
-        ORDER BY a.created_at DESC
+        ORDER BY a.created_at ${order}
     ;`
 
     return db.query(sqlQueryString, queryValues)

--- a/models/articles.models.js
+++ b/models/articles.models.js
@@ -1,6 +1,6 @@
 const db = require('../db/connection')
 
-exports.selectArticles = (topic, order = 'desc') => {
+exports.selectArticles = (topic, sort_by = 'created_at', order = 'desc') => {
     let sqlQueryString = `
         SELECT  a.author,
         a.title,
@@ -29,7 +29,7 @@ exports.selectArticles = (topic, order = 'desc') => {
         a.votes,
         a.article_img_url,
         a.topic
-        ORDER BY a.created_at ${order}
+        ORDER BY a.${sort_by} ${order}
     ;`
 
     return db.query(sqlQueryString, queryValues)


### PR DESCRIPTION
# Feature request: sorting queries on GET /api/articles

Introduces enhanced sorting capabilities for the `GET /api/articles` endpoint

## Feature testing & implementation
* Adds a __200__ test for implementation of order query
    * Still defaults to descending but can now be changed with `?order=asc` query in the endpoint
* Adds a __200__ test for implementation of sort_by query
    * Defaults to `created_at`
    * Both defaults dealt with by adding default parameters in the model function
* Adds a further __200__ test for sort_by, for the case where the column specified is `comment_count`, which comes from the JOIN comments table
    * The way I set up my db query necessitated this extra test - I have my articles table aliased as ‘a’, so all articles columns need to be prepended with ‘a.’ The comment_count comes from the comments table via JOIN, is specifically aliased AS `comment_count` in the query, and therefore needs to not have the ‘a.’ prepending it when added in to the string literal
## Error handling / SQL injection protection 
* Adds a __400__ sad path test for invalid order query (not `asc` or `desc`)
* Adds a __404__ sad path test for an invalid column name in the sort_by query
    * Both validated in the model to prevent sql injection before being passed into the string literal 
