### PR TITLE
Ticket 18: PATCH /api/comments/:comment_id

### DIFF
--- a/__tests__/app.test.js
+++ b/__tests__/app.test.js
@@ -427,6 +427,16 @@ describe('/api/comments/:comment_id', () => {
                 expect(comment).toMatchObject(expected)
             })
         })
+        test('PATCH 400: responds with a bad request if inc_votes value is not a number', () => {
+            const testPatch = { inc_votes : 'not a number' } 
+            return request(app)
+            .patch('/api/comments/1')
+            .send(testPatch)
+            .expect(400)
+            .then(({ body: { msg } })  => {
+                expect(msg).toBe('Bad request')
+            })
+        })
     })
 })
 

--- a/__tests__/app.test.js
+++ b/__tests__/app.test.js
@@ -409,6 +409,25 @@ describe('/api/comments/:comment_id', () => {
             })
         })
     })
+    describe('PATCH TESTS', () => {
+        test('PATCH 200: responds with correctly updated votes in comment object', () => {
+            const testPatch = { inc_votes : 1 } 
+            return request(app)
+            .patch('/api/comments/1')
+            .send(testPatch)
+            .expect(200)
+            .then(({ body: { comment }}) => {
+                const expected = { 
+                    comment_id: 1, 
+                    body: "Oh, I've got compassion running out of my nose, pal! I'm the Sultan of Sentiment!", 
+                    votes: 17, 
+                    author: 'butter_bridge',
+                    article_id: 9, 
+                }
+                expect(comment).toMatchObject(expected)
+            })
+        })
+    })
 })
 
 describe('/api/users', () => {

--- a/__tests__/app.test.js
+++ b/__tests__/app.test.js
@@ -427,8 +427,18 @@ describe('/api/comments/:comment_id', () => {
                 expect(comment).toMatchObject(expected)
             })
         })
-        test('PATCH 400: responds with a bad request if inc_votes value is not a number', () => {
+        test('PATCH 400: responds with a bad request error if inc_votes value is not a number', () => {
             const testPatch = { inc_votes : 'not a number' } 
+            return request(app)
+            .patch('/api/comments/1')
+            .send(testPatch)
+            .expect(400)
+            .then(({ body: { msg } })  => {
+                expect(msg).toBe('Bad request')
+            })
+        })
+        test('PATCH 400: responds with a bad request error if inc_votes property not present', () => {
+            const testPatch = { invalid_key : 1 } 
             return request(app)
             .patch('/api/comments/1')
             .send(testPatch)

--- a/__tests__/app.test.js
+++ b/__tests__/app.test.js
@@ -447,6 +447,16 @@ describe('/api/comments/:comment_id', () => {
                 expect(msg).toBe('Bad request')
             })
         })
+        test('PATCH 404: responds with a not found error if comment_id does not exist in db', () => {
+            const testPatch = { inc_votes : 1 } 
+            return request(app)
+            .patch('/api/comments/9999')
+            .send(testPatch)
+            .expect(404)
+            .then(({ body: { msg } })  => {
+                expect(msg).toBe('Comment not found')
+            })
+        })
     })
 })
 

--- a/controllers/comments.controllers.js
+++ b/controllers/comments.controllers.js
@@ -41,4 +41,5 @@ exports.patchVotesByCommentId = (req, res, next) => {
     .then((comment) => {
         res.status(200).send({ comment })
     })
+    .catch(next)
 }

--- a/controllers/comments.controllers.js
+++ b/controllers/comments.controllers.js
@@ -1,5 +1,5 @@
 const { checkArticleExists } = require("../models/articles.models")
-const { selectCommentsByArticleId, insertCommentByArticleId, removeCommentByCommentId } = require("../models/comments.models")
+const { selectCommentsByArticleId, insertCommentByArticleId, removeCommentByCommentId, updateVotesByCommentId } = require("../models/comments.models")
 const { checkUserExists } = require("../models/users.models")
 
 exports.getCommentsByArticleId = (req, res, next) => {
@@ -32,4 +32,13 @@ exports.deleteCommentByCommentId = (req, res, next) => {
         res.status(204).send()
     })
     .catch(next)
+}
+
+exports.patchVotesByCommentId = (req, res, next) => {
+    const { comment_id } = req.params
+    const body = req.body
+    return updateVotesByCommentId(comment_id, body)
+    .then((comment) => {
+        res.status(200).send({ comment })
+    })
 }

--- a/endpoints.json
+++ b/endpoints.json
@@ -98,6 +98,20 @@
     "description": "deletes a comment and serves no body back",
     "queries": []
   },
+  "PATCH /api/comments/:comment_id": {
+    "description": "updates votes on a comment with inc_votes number sent, serves back the comment with correctly updated votes total",
+    "queries": [],
+    "exampleRequest": { "inc_votes" : 1 },
+    "exampleResponse": {
+      "comment": {
+          "comment_id": 1, 
+          "body": "Oh, I've got compassion running out of my nose, pal! I'm the Sultan of Sentiment!", 
+          "votes": 17, 
+          "author": "butter_bridge",
+          "article_id": 9
+      }
+    }
+  },
   "GET /api/users": {
     "description": "serves an array of all users",
     "queries": [],

--- a/models/comments.models.js
+++ b/models/comments.models.js
@@ -34,3 +34,15 @@ exports.removeCommentByCommentId = (comment_id) => {
         }
     })
 }
+
+exports.updateVotesByCommentId = (comment_id, { inc_votes }) => {
+    return db.query(`
+        UPDATE comments
+        SET votes = votes + $1
+        WHERE comment_id = $2
+        RETURNING *
+    ;`, [inc_votes, comment_id])
+    .then(({ rows }) => {
+        return rows[0]
+    })
+}

--- a/models/comments.models.js
+++ b/models/comments.models.js
@@ -43,6 +43,9 @@ exports.updateVotesByCommentId = (comment_id, { inc_votes }) => {
         RETURNING *
     ;`, [inc_votes, comment_id])
     .then(({ rows }) => {
+        if (rows.length === 0){
+            return Promise.reject({ status: 404, msg: "Comment not found" })
+        }
         return rows[0]
     })
 }

--- a/routes/comments-router.js
+++ b/routes/comments-router.js
@@ -1,9 +1,10 @@
 const commentsRouter = require('express').Router()
 
-const { deleteCommentByCommentId } = require('../controllers/comments.controllers')
+const { deleteCommentByCommentId, patchVotesByCommentId } = require('../controllers/comments.controllers')
 
 commentsRouter
     .route('/:comment_id')
     .delete(deleteCommentByCommentId)
+    .patch(patchVotesByCommentId)
 
 module.exports = commentsRouter


### PR DESCRIPTION
# PATCH comment votes by comment_id

Adds the ability to update votes property of a comment, in similar fashion to updating votes on articles

## Endpoint testing & implementation
* Adds __200__ test and functionality for successful PATCH of votes on a specified comment_id
    * Serves back comment with correctly updated vote count
* Adds sad path tests and functionality for:
    * __400__: invalid type on `inc_votes` (__22P02__ code in psql error handling - invalid input syntax)
    * __400__: `inc_votes` property not present in patch object sent (__23503__ code in psql error handling - null value in column)
    * __404__: `comment_id` not found in db (rows length check in  the model)

## Other
* Updates endpoints.json with info about this endpoint