### PR TITLE
Ticket 20: Pagination GET /api/articles

### DIFF
--- a/__tests__/app.test.js
+++ b/__tests__/app.test.js
@@ -58,7 +58,7 @@ describe('/api/articles', () => {
             .get('/api/articles')
             .expect(200)
             .then(({ body: { articles } }) => {
-                expect(articles).toHaveLength(13)
+                expect(articles.length).toBeGreaterThan(0)
                 articles.forEach((article) => {
                     const { author, title, article_id, topic, created_at, votes, article_img_url } = article
                     expect(typeof author).toBe('string')
@@ -153,6 +153,17 @@ describe('/api/articles', () => {
             .expect(404)
             .then(({ body: { msg } }) => {
                 expect(msg).toBe('Column not found')
+            })
+        })
+        describe('PAGINATION TESTS', () => {
+            test('GET 200: responds with aticles array limited to length of 10 by default, served body has a total_count property equal to number of articles in db', () => {
+                return request(app)
+                .get('/api/articles')
+                .expect(200)
+                .then(({ body: { articles, total_count } }) => {
+                    expect(articles).toHaveLength(10)
+                    expect(total_count).toBe(13)
+                })
             })
         })
     })

--- a/__tests__/app.test.js
+++ b/__tests__/app.test.js
@@ -182,6 +182,14 @@ describe('/api/articles', () => {
                     expect(articles).toHaveLength(5)
                 }) 
             })
+            test('GET 200: responds with articles array offset by p query, with single page length specified by limit (default 10)', () => {
+                return request(app)
+                .get('/api/articles?p=2')
+                .expect(200)
+                .then(({ body: { articles } }) => {
+                    expect(articles).toHaveLength(3)
+                }) 
+            })
         })
     })
     describe('POST TESTS:', () => {

--- a/__tests__/app.test.js
+++ b/__tests__/app.test.js
@@ -190,6 +190,14 @@ describe('/api/articles', () => {
                     expect(articles).toHaveLength(3)
                 }) 
             })
+            test('GET 400: responds with a bad request error if limit is not a number', ()=>{
+                return request(app)
+                .get('/api/articles?limit=not_a_number')
+                .expect(400)
+                .then(({ body: { msg } }) => {
+                    expect(msg).toBe('Bad request')
+                }) 
+            })
         })
     })
     describe('POST TESTS:', () => {

--- a/__tests__/app.test.js
+++ b/__tests__/app.test.js
@@ -198,6 +198,14 @@ describe('/api/articles', () => {
                     expect(msg).toBe('Bad request')
                 }) 
             })
+            test('GET 400: responds with a bad request error if p is not a number', ()=>{
+                return request(app)
+                .get('/api/articles?p=not_a_number')
+                .expect(400)
+                .then(({ body: { msg } }) => {
+                    expect(msg).toBe('Bad request')
+                }) 
+            })
         })
     })
     describe('POST TESTS:', () => {

--- a/__tests__/app.test.js
+++ b/__tests__/app.test.js
@@ -174,6 +174,14 @@ describe('/api/articles', () => {
                     expect(total_count).toBe(12)
                 })
             })
+            test('GET 200: responds with articles array length matching limit query if specified', () => {
+                return request(app)
+                .get('/api/articles?limit=5')
+                .expect(200)
+                .then(({ body: { articles } }) => {
+                    expect(articles).toHaveLength(5)
+                }) 
+            })
         })
     })
     describe('POST TESTS:', () => {

--- a/__tests__/app.test.js
+++ b/__tests__/app.test.js
@@ -165,6 +165,15 @@ describe('/api/articles', () => {
                     expect(total_count).toBe(13)
                 })
             })
+            test('GET 200: responds with correctly calculated total_count number if filtered by topic query', () => {
+                return request(app)
+                .get('/api/articles?topic=mitch')
+                .expect(200)
+                .then(({ body: { articles, total_count } }) => {
+                    expect(articles).toHaveLength(10)
+                    expect(total_count).toBe(12)
+                })
+            })
         })
     })
     describe('POST TESTS:', () => {

--- a/controllers/articles.controllers.js
+++ b/controllers/articles.controllers.js
@@ -2,9 +2,9 @@ const { selectArticleById, selectArticles, updateVotesByArticleId, checkArticleE
 const { checkTopicExists } = require("../models/topics.models")
 
 exports.getArticles = (req, res, next) => {
-    const { topic, sort_by, order } = req.query
-    return Promise.all([selectArticles(topic, sort_by, order), checkTopicExists(topic)])
-    .then(([ articles ]) => res.status(200).send({ articles }))
+    const { topic, sort_by, order, limit } = req.query
+    return Promise.all([selectArticles(topic, sort_by, order, limit), checkTopicExists(topic)])
+    .then(([[ articles, total_count ]]) => res.status(200).send({articles, total_count}))
     .catch(next)
 }
 

--- a/controllers/articles.controllers.js
+++ b/controllers/articles.controllers.js
@@ -2,8 +2,8 @@ const { selectArticleById, selectArticles, updateVotesByArticleId, checkArticleE
 const { checkTopicExists } = require("../models/topics.models")
 
 exports.getArticles = (req, res, next) => {
-    const { topic, sort_by, order, limit } = req.query
-    return Promise.all([selectArticles(topic, sort_by, order, limit), checkTopicExists(topic)])
+    const { topic, sort_by, order, limit, p } = req.query
+    return Promise.all([selectArticles(topic, sort_by, order, limit, p), checkTopicExists(topic)])
     .then(([[ articles, total_count ]]) => res.status(200).send({articles, total_count}))
     .catch(next)
 }

--- a/endpoints.json
+++ b/endpoints.json
@@ -10,8 +10,8 @@
     }
   },
   "GET /api/articles": {
-    "description": "serves an array of all articles. topic query filters served array by specified topic. sort_by query can take any of the column names seen below in the example response - defaults to created_at. order query can take asc or desc - defaults to desc ",
-    "queries": ["topic", "sort_by", "order"],
+    "description": "serves an array of all articles and a total_count of articles found by query. topic query filters the served array by specified topic. sort_by query can take any of the column names seen below in the example response - defaults to created_at. order query can take asc or desc - defaults to desc. limit query takes a number and limits the served array to that length - defaults to 10. p query stands for page - articles array will be offset by number of pages, with page length specified by limit - p defaults to 1",
+    "queries": ["topic", "sort_by", "order", "limit", "p"],
     "exampleResponse": {
       "articles": [
         {
@@ -23,7 +23,8 @@
           "votes": 0,
           "comment_count": 6
         }
-      ]
+      ],
+      "total_count": 13
     }
   },
   "POST /api/articles": {

--- a/models/articles.models.js
+++ b/models/articles.models.js
@@ -17,7 +17,7 @@ exports.selectArticles = (topic, sort_by = 'created_at', order = 'desc', limit =
         SELECT COUNT(DISTINCT a.article_id):: INT AS total_count
         FROM articles a 
         LEFT JOIN comments c
-        ON a.article_id = c.article_id ;`
+        ON a.article_id = c.article_id `
 
     let sqlQueryString = `
         SELECT  a.author,
@@ -36,6 +36,7 @@ exports.selectArticles = (topic, sort_by = 'created_at', order = 'desc', limit =
 
     if (topic){
         sqlQueryString += `WHERE a.topic = $1 `
+        getTotalCountQuery += `WHERE a.topic = $1 ;`
         queryValues.push(topic)
     }
 
@@ -51,7 +52,7 @@ exports.selectArticles = (topic, sort_by = 'created_at', order = 'desc', limit =
         LIMIT ${limit}
     ;`
 
-    return db.query(getTotalCountQuery)
+    return db.query(getTotalCountQuery, queryValues)
     .then(({ rows: [ { total_count } ]}) => {
         return db.query(sqlQueryString, queryValues)
         .then(({ rows }) => [rows, total_count])

--- a/models/articles.models.js
+++ b/models/articles.models.js
@@ -1,7 +1,7 @@
 const db = require('../db/connection')
 const { commentData } = require('../db/data/test-data')
 
-exports.selectArticles = (topic, sort_by = 'created_at', order = 'desc', limit = 10) => {
+exports.selectArticles = (topic, sort_by = 'created_at', order = 'desc', limit = 10, p = 1) => {
     const validOrders = ['asc', 'desc']
     const validSortBys = ['author', 'title', 'article_id', 'created_at', 'article_img_url', 'topic', 'comment_count']
     if(!validOrders.includes(order)){
@@ -49,9 +49,9 @@ exports.selectArticles = (topic, sort_by = 'created_at', order = 'desc', limit =
         a.article_img_url,
         a.topic
         ORDER BY ${sort_by} ${order}
-        LIMIT ${limit}
+        LIMIT ${limit} OFFSET ${(p-1) * limit}
     ;`
-
+    
     return db.query(getTotalCountQuery, queryValues)
     .then(({ rows: [ { total_count } ]}) => {
         return db.query(sqlQueryString, queryValues)

--- a/models/articles.models.js
+++ b/models/articles.models.js
@@ -5,7 +5,7 @@ exports.selectArticles = (topic, sort_by = 'created_at', order = 'desc', limit =
     const validOrders = ['asc', 'desc']
     const validSortBys = ['author', 'title', 'article_id', 'created_at', 'article_img_url', 'topic', 'comment_count']
     
-    if(!validOrders.includes(order) || isNaN(parseInt(limit))){
+    if(!validOrders.includes(order) || isNaN(parseInt(limit)) || isNaN(parseInt(p)) ){
         return Promise.reject({ status: 400, msg: 'Bad request'})
     }
     if(!validSortBys.includes(sort_by)){

--- a/models/articles.models.js
+++ b/models/articles.models.js
@@ -4,15 +4,18 @@ const { commentData } = require('../db/data/test-data')
 exports.selectArticles = (topic, sort_by = 'created_at', order = 'desc', limit = 10, p = 1) => {
     const validOrders = ['asc', 'desc']
     const validSortBys = ['author', 'title', 'article_id', 'created_at', 'article_img_url', 'topic', 'comment_count']
-    if(!validOrders.includes(order)){
+    
+    if(!validOrders.includes(order) || isNaN(parseInt(limit))){
         return Promise.reject({ status: 400, msg: 'Bad request'})
     }
     if(!validSortBys.includes(sort_by)){
         return Promise.reject({ status: 404, msg: 'Column not found'})
     }
+    
     if(sort_by !== 'comment_count'){
         sort_by = `a.${sort_by}`
     }
+    
     let getTotalCountQuery = `
         SELECT COUNT(DISTINCT a.article_id):: INT AS total_count
         FROM articles a 
@@ -51,7 +54,7 @@ exports.selectArticles = (topic, sort_by = 'created_at', order = 'desc', limit =
         ORDER BY ${sort_by} ${order}
         LIMIT ${limit} OFFSET ${(p-1) * limit}
     ;`
-    
+
     return db.query(getTotalCountQuery, queryValues)
     .then(({ rows: [ { total_count } ]}) => {
         return db.query(sqlQueryString, queryValues)


### PR DESCRIPTION
# Pagination for articles

Adds the ability for served article array length to by specified by limit query, with a default of 10, and to be offset by p query, with a default of 1 (i.e 1st page of articles)


## Endpoint testing & implementation
* __200 TESTS__ 
    * Default limit of 10 applied, and `total_count` being calculated and served back in response object
    * `total_count` being updated dynamically when results are filtered by topic
    * `limit` query working when not left to default
    * `p` working to offset results by page * limit (actually p-1 because page 1 should not be offset)
* __400__ TESTS
    * checks that `limit` is a valid number, rejects if not, protecting against sql injection
    * same again but for `p` 

## Other
* Updates endpoints.json with info about `limit` and `p`, and includes the `total_count` property in the exampleResponse